### PR TITLE
minor installation bags fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "flexycms/flexyadminframe-bundle",
-  "version": "0.1.4.5",
+  "version": "0.1.4.6",
   "type": "symfony-bundle",
   "description": "Main frame for admin panel",
   "license": "proprietary",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,7 +1,6 @@
 parameters:
 # Здесь могут быть параметры бандла
   panelMenuTemplate: "@@FlexyAdminFrame/panelmenu.html.twig"
-  uploads_path: '/public/uploads/embedded'
 
 services:
 

--- a/src/FlexyAdminFrameBundle.php
+++ b/src/FlexyAdminFrameBundle.php
@@ -23,10 +23,13 @@ Options +SymLinksIfOwnerMatch
 #Options +FollowSymlinks
 RewriteRule ^(.+)$ /public/ [QSA,L]";
 
-        $rootDir = __DIR__ . "../../../../..";
+        $rootDir = $container->getParameter('kernel.project_dir');
 
-        if (is_file($rootDir . "/.htaccess")) unlink($rootDir . "/.htaccess");
-        file_put_contents($rootDir . "/.htaccess", $htaccess);
+        dump($rootDir);
+
+        if (!is_file($rootDir . "/.htaccess")) {
+            file_put_contents($rootDir . "/.htaccess", $htaccess);
+        }
 
         if (!is_dir($rootDir . "/public")) mkdir($rootDir . "/public");
         if (!is_dir($rootDir . "/public/uploads")) mkdir($rootDir . "/public/uploads");


### PR DESCRIPTION
1. Параметр uploads_path перенесён в Filemanager bundle и теперь назвается flexycms.upload_path
2. Способ определения корневой директории в настройках бандла заменён на получение пути из kernel